### PR TITLE
Fix TGI version to avoid cuda issues

### DIFF
--- a/tgi.slurm
+++ b/tgi.slurm
@@ -52,7 +52,7 @@ for node in $(scontrol show hostnames $SLURM_JOB_NODELIST); do
     sudo docker run \
         --gpus "\"device=$CUDA_VISIBLE_DEVICES"\" --shm-size 1g \
         -v $volume:/data -p $PORT:80 \
-        ghcr.io/huggingface/text-generation-inference \
+        ghcr.io/huggingface/text-generation-inference:1.1.0 \
         --model-id $model --max-concurrent-requests 530 --max-total-tokens 8192 --max-input-length 7168 --max-batch-prefill-tokens 7168 &  # run in background
 done
 

--- a/tgi_template.slurm
+++ b/tgi_template.slurm
@@ -43,7 +43,7 @@ for node in $(scontrol show hostnames $SLURM_JOB_NODELIST); do
     sudo docker run \
         --gpus "\"device=$CUDA_VISIBLE_DEVICES"\" --shm-size 1g \
         -v $volume:/data -p $PORT:80 \
-        ghcr.io/huggingface/text-generation-inference \
+        ghcr.io/huggingface/text-generation-inference:1.1.0 \
         --model-id $model --max-concurrent-requests 530 --max-total-tokens 8192 --max-input-length 7168 --max-batch-prefill-tokens 7168 &  # run in background
 done
 


### PR DESCRIPTION
This PR fixes the TGI version; using the latest 1.1.1 results in the following cuda errors.

```
costa@ip-26-0-154-65:/fsx/costa/tgi-swarm$ sudo docker run --gpus all --shm-size 1g -p 8080:80 -v /scratch:/data ghcr.io/huggingface/text-generation-inference:1.1.1 --model-id mistralai/Mistral-7B-Instruct-v0.1
Unable to find image 'ghcr.io/huggingface/text-generation-inference:1.1.1' locally
1.1.1: Pulling from huggingface/text-generation-inference
5ed4b6922ffb: Pull complete 
Digest: sha256:8ec3bb27bdadc2faa09d2a687f6325e2cef0a3ff9b7c3c35b59416cc0d293c67
Status: Downloaded newer image for ghcr.io/huggingface/text-generation-inference:1.1.1
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: Auto-detected mode as 'legacy'
nvidia-container-cli: requirement error: unsatisfied condition: cuda>=11.8, please update your driver to a newer version, or use an earlier cuda container: unknown.
ERRO[0106] error waiting for container: context canceled 
```