### PR TITLE
use `fsx` as cache for TGI

### DIFF
--- a/tgi_h100.slurm
+++ b/tgi_h100.slurm
@@ -6,7 +6,7 @@
 #SBATCH --mem-per-cpu=11G
 #SBATCH -o slurm/logs/%x_%j.out
 
-export volume=/scratch
+export volume=/fsx/.cache/tgi
 export model=mistralai/Mistral-7B-Instruct-v0.1
 
 function unused_port() {
@@ -21,7 +21,7 @@ function unused_port() {
         head -n "$N"
 }
 export PORT=$(unused_port)
-export HUGGING_FACE_HUB_TOKEN=HF_TOKEN
+export HUGGING_FACE_HUB_TOKEN=$HF_TOKEN
 
 if [ -z "$HUGGING_FACE_HUB_TOKEN" ]; then
   echo "You should provide a Hugging Face token in HUGGING_FACE_HUB_TOKEN."
@@ -32,13 +32,13 @@ echo "Starting TGI container port $PORT"
 # you can cache the container image in /fsx/.../huggingface+text-generation-inference.sqsh'
 srun --container-image='ghcr.io#huggingface/text-generation-inference' \
      --container-env=HUGGING_FACE_HUB_TOKEN,PORT \
-     --container-mounts="/scratch:/data" \
+     --container-mounts="$volume:/data" \
      --no-container-mount-home \
      --qos normal \
      /usr/local/bin/text-generation-launcher --model-id $model \
      --max-concurrent-requests 530 \
-     --max-total-tokens 4096 \
-     --max-input-length 2048 \
+     --max-total-tokens 8192 \
+     --max-input-length 7144 \
      --max-batch-prefill-tokens 8192 \
     
 echo "End of job"


### PR DESCRIPTION
This way we are sharing storage and not having to download mistral model every time! CC @loubnabnl 