### PR TITLE
Add textbooks example with re-try/sleep period to avoid overloading the endpoints

### DIFF
--- a/examples/textbooks/generate_openstax.py
+++ b/examples/textbooks/generate_openstax.py
@@ -17,9 +17,9 @@ HF_TOKEN = os.environ.get("HF_TOKEN", None)
 class Args:
     max_samples: int = 50000
     """The maximum umber of samples to generate (use -1 for all))"""
-    instances: int = 5
+    tgi_instances: int = 5
     """Number of TGI instances to use"""
-    model: str = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+    model_name: str = "mistralai/Mixtral-8x7B-Instruct-v0.1"
     """Model to prompt"""
     max_new_tokens: int = 2100
     """Max new tokens"""
@@ -44,9 +44,9 @@ args, isc = parser.parse_args_into_dataclasses()
 print(args)
 
 # overwrite model and number of instances
-isc.model = args.model
-isc.instances = args.instances
-tokenizer = AutoTokenizer.from_pretrained(args.model)
+isc.model = args.model_name
+isc.instances = args.tgi_instances
+tokenizer = AutoTokenizer.from_pretrained(args.model_name)
 
 ds = load_dataset(
     "HuggingFaceTB/openstax_prompts_concatenated", token=HF_TOKEN, split="train"
@@ -90,7 +90,7 @@ with LLMSwarm(isc) as llm_swarm:
                     sample["token_length"] = token_length
                     return sample
 
-            except Exception as e:  # Replace with specific exceptions if known
+            except Exception as e: 
                 attempt += 1
                 if attempt < MAX_RETRIES:
                     print(

--- a/examples/textbooks/generate_openstax.py
+++ b/examples/textbooks/generate_openstax.py
@@ -4,21 +4,24 @@ import time
 from dataclasses import dataclass
 
 import pandas as pd
-from datasets import load_dataset, Dataset
+from datasets import Dataset, load_dataset
 from huggingface_hub import AsyncInferenceClient
+from llm_swarm import LLMSwarm, LLMSwarmConfig
 from tqdm.asyncio import tqdm_asyncio
 from transformers import AutoTokenizer, HfArgumentParser
 
-from llm_swarm import LLMSwarm, LLMSwarmConfig
-
-
 HF_TOKEN = os.environ.get("HF_TOKEN", None)
+
 
 @dataclass
 class Args:
-    max_samples: int = -1
+    max_samples: int = 50000
     """The maximum umber of samples to generate (use -1 for all))"""
-    max_new_tokens: int = 3000
+    instances: int = 5
+    """Number of TGI instances to use"""
+    model: str = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+    """Model to prompt"""
+    max_new_tokens: int = 2100
     """Max new tokens"""
     temperature: float = 0.6
     """Generation temperature"""
@@ -35,13 +38,15 @@ class Args:
     push_to_hub: bool = True
     """Whether to push to hub"""
 
-# mixtral throughput 4290
+
 parser = HfArgumentParser((Args, LLMSwarmConfig))
 args, isc = parser.parse_args_into_dataclasses()
 print(args)
-isc.model = "mistralai/Mixtral-8x7B-Instruct-v0.1"
-isc.instances = 10
-tokenizer = AutoTokenizer.from_pretrained("mistralai/Mixtral-8x7B-Instruct-v0.1")
+
+# overwrite model and number of instances
+isc.model = args.model
+isc.instances = args.instances
+tokenizer = AutoTokenizer.from_pretrained(args.model)
 
 ds = load_dataset(
     "HuggingFaceTB/openstax_prompts_concatenated", token=HF_TOKEN, split="train"
@@ -56,28 +61,49 @@ with LLMSwarm(isc) as llm_swarm:
     client = AsyncInferenceClient(model=llm_swarm.endpoint)
     STOP_SEQ = ["<|endoftext|>"]
 
+    MAX_RETRIES = 3  # maximum number of retries
+    RETRY_DELAY = 5  # delay in seconds between retries
+
     async def process_text(sample):
         token_length = 0
-        async with semaphore:
-            completion = await client.text_generation(
-                prompt=tokenizer.apply_chat_template(
-                    [{"role": "user", "content": sample[args.prompt_column]}],
-                    tokenize=False,
-                ),
-                max_new_tokens=args.max_new_tokens,
-                stop_sequences=STOP_SEQ,
-                temperature=args.temperature,
-                top_p=args.top_p,
-                top_k=args.top_k,
-                repetition_penalty=args.repetition_penalty,
-            )
-            for stop_seq in STOP_SEQ:
-                if completion.endswith(stop_seq):
-                    completion = completion[: -len(stop_seq)].rstrip()
-            token_length += len(tokenizer.encode(completion))
-        sample["completion"] = completion
-        sample["token_length"] = token_length
-        return sample
+        attempt = 0
+        while attempt < MAX_RETRIES:
+            try:
+                async with semaphore:
+                    completion = await client.text_generation(
+                        prompt=tokenizer.apply_chat_template(
+                            [{"role": "user", "content": sample[args.prompt_column]}],
+                            tokenize=False,
+                        ),
+                        max_new_tokens=args.max_new_tokens,
+                        stop_sequences=STOP_SEQ,
+                        temperature=args.temperature,
+                        top_p=args.top_p,
+                        top_k=args.top_k,
+                        repetition_penalty=args.repetition_penalty,
+                    )
+                    for stop_seq in STOP_SEQ:
+                        if completion.endswith(stop_seq):
+                            completion = completion[: -len(stop_seq)].rstrip()
+                    token_length += len(tokenizer.encode(completion))
+                    sample["completion"] = completion
+                    sample["token_length"] = token_length
+                    return sample
+
+            except Exception as e:  # Replace with specific exceptions if known
+                attempt += 1
+                if attempt < MAX_RETRIES:
+                    print(
+                        f"Request failed, retrying in {RETRY_DELAY} seconds... (Attempt {attempt}/{MAX_RETRIES})"
+                    )
+                    await asyncio.sleep(RETRY_DELAY)
+                else:
+                    print(
+                        f"Max retries reached. Failed to process the request with error {str(e)}."
+                    )
+                    sample["completion"] = ""
+                    sample["token_length"] = 0
+                    return sample
 
     async def main():
         start_time = time.time()
@@ -87,10 +113,14 @@ with LLMSwarm(isc) as llm_swarm:
         output_ds = Dataset.from_pandas(df)
         total_duration = end_time - start_time
         total_tokens = sum(output_ds["token_length"])
-        overall_tokens_per_second = total_tokens / total_duration if total_duration > 0 else 0
+        overall_tokens_per_second = (
+            total_tokens / total_duration if total_duration > 0 else 0
+        )
         print(f"Overall Tokens per Second: {overall_tokens_per_second}")
-        print(output_ds)
 
+        # remove empty completions
+        output_ds = output_ds.filter(lambda x: x["completion"] != "")
+        print(output_ds)
         if args.push_to_hub:
             output_ds.push_to_hub(args.repo_id, private=True)
 

--- a/examples/textbooks/generate_openstax.py
+++ b/examples/textbooks/generate_openstax.py
@@ -1,0 +1,97 @@
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+
+import pandas as pd
+from datasets import load_dataset, Dataset
+from huggingface_hub import AsyncInferenceClient
+from tqdm.asyncio import tqdm_asyncio
+from transformers import AutoTokenizer, HfArgumentParser
+
+from llm_swarm import LLMSwarm, LLMSwarmConfig
+
+
+HF_TOKEN = os.environ.get("HF_TOKEN", None)
+
+@dataclass
+class Args:
+    max_samples: int = -1
+    """The maximum umber of samples to generate (use -1 for all))"""
+    max_new_tokens: int = 3000
+    """Max new tokens"""
+    temperature: float = 0.6
+    """Generation temperature"""
+    top_p: float = 0.95
+    """Generation top_p"""
+    top_k: int = 50
+    """Generation top_k"""
+    repetition_penalty: float = 1.2
+    """Generation repetition_penalty"""
+    prompt_column: str = "prompt"
+    """Name of the column containing the prompt"""
+    repo_id: str = "HuggingFaceTB/openstax_generations_f"
+    """The repo id to push to"""
+    push_to_hub: bool = True
+    """Whether to push to hub"""
+
+# mixtral throughput 4290
+parser = HfArgumentParser((Args, LLMSwarmConfig))
+args, isc = parser.parse_args_into_dataclasses()
+print(args)
+isc.model = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+isc.instances = 10
+tokenizer = AutoTokenizer.from_pretrained("mistralai/Mixtral-8x7B-Instruct-v0.1")
+
+ds = load_dataset(
+    "HuggingFaceTB/openstax_prompts_concatenated", token=HF_TOKEN, split="train"
+).shuffle(seed=42)
+
+if args.max_samples > 0:
+    ds = ds.select(range(args.max_samples))
+
+
+with LLMSwarm(isc) as llm_swarm:
+    semaphore = asyncio.Semaphore(llm_swarm.suggested_max_parallel_requests)
+    client = AsyncInferenceClient(model=llm_swarm.endpoint)
+    STOP_SEQ = ["<|endoftext|>"]
+
+    async def process_text(sample):
+        token_length = 0
+        async with semaphore:
+            completion = await client.text_generation(
+                prompt=tokenizer.apply_chat_template(
+                    [{"role": "user", "content": sample[args.prompt_column]}],
+                    tokenize=False,
+                ),
+                max_new_tokens=args.max_new_tokens,
+                stop_sequences=STOP_SEQ,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                top_k=args.top_k,
+                repetition_penalty=args.repetition_penalty,
+            )
+            for stop_seq in STOP_SEQ:
+                if completion.endswith(stop_seq):
+                    completion = completion[: -len(stop_seq)].rstrip()
+            token_length += len(tokenizer.encode(completion))
+        sample["completion"] = completion
+        sample["token_length"] = token_length
+        return sample
+
+    async def main():
+        start_time = time.time()
+        results = await tqdm_asyncio.gather(*(process_text(sample) for sample in ds))
+        end_time = time.time()
+        df = pd.DataFrame(results)
+        output_ds = Dataset.from_pandas(df)
+        total_duration = end_time - start_time
+        total_tokens = sum(output_ds["token_length"])
+        overall_tokens_per_second = total_tokens / total_duration if total_duration > 0 else 0
+        print(f"Overall Tokens per Second: {overall_tokens_per_second}")
+        print(output_ds)
+
+        if args.push_to_hub:
+            output_ds.push_to_hub(args.repo_id, private=True)
+
+    asyncio.run(main())

--- a/examples/textbooks/readme.md
+++ b/examples/textbooks/readme.md
@@ -70,3 +70,4 @@ running scancel 1625163
 running scancel 1625164
 running scancel 1625165
 ```
+Note: the `generate_rw_textbooks.py` requires installing  `requirements.txt` and  `datatrove` from source.

--- a/examples/textbooks/readme.md
+++ b/examples/textbooks/readme.md
@@ -1,6 +1,72 @@
 # Guidelines
 
 
+```bash
+python ./examples/textbooks/generate_openstax.py --tgi_instances 5 --max_samples 50000
 ```
-python ./examples/textbooks/generate_openstax.py --tgi_instances 2 --max_samples 10000
+```
+(textbooks) loubna@login-node-1:/fsx/loubna/projects/llm-swarm$ python ./examples/textbooks/generate_openstax.py             
+Args(max_samples=50000, max_new_tokens=2100, temperature=0.6, top_p=0.95, top_k=50, repetition_penalty=1.2, prompt_column='prompt', repo_id='HuggingFaceTB/o
+penstax_generations_f', push_to_hub=True)                                                                                                                   
+running sbatch --parsable slurm/tgi_1706882419_tgi.slurm                                                                                            
+running sbatch --parsable slurm/tgi_1706882419_tgi.slurm                                                                                            
+running sbatch --parsable slurm/tgi_1706882419_tgi.slurm                                                                                            
+running sbatch --parsable slurm/tgi_1706882419_tgi.slurm                                                                                            
+running sbatch --parsable slurm/tgi_1706882419_tgi.slurm                                                                                                    
+Slurm Job ID: ['1625161', '1625162', '1625163', '1625164', '1625165']                                                                                       
+📖 Slurm hosts path: slurm/tgi_1706882419_host_tgi.txt                                                                                                      
+✅ Done! Waiting for 1625161 to be created                                                                                                                  
+📖 Slurm log path: slurm/logs/llm-swarm_1625161.out                                                                                                         
+✅ Done! Waiting for 1625162 to be created                                                                                                                  
+📖 Slurm log path: slurm/logs/llm-swarm_1625162.out                                                                                                         
+✅ Done! Waiting for 1625163 to be created                                                                                                          ...                                                                                       
+obtained endpoints ['http://26.0.172.147:22882', 'http://26.0.175.19:32335', 'http://26.0.172.142:53787', 'http://26.0.172.252:44532', 'http://26.0.173.7:28
+863']                                                                                                                                                       
+⣽ Waiting for http://26.0.172.147:22882 to be reachable                                                                                                     
+Connected to http://26.0.172.147:22882                                                                                                                      
+✅ Done! Waiting for http://26.0.172.147:22882 to be reachable                                                                                              
+⣟ Waiting for http://26.0.175.19:32335 to be reachable                                                                                                      
+Connected to http://26.0.175.19:32335                                                                                                               ...              
+Endpoints running properly: ['http://26.0.172.147:22882', 'http://26.0.175.19:32335', 'http://26.0.172.142:53787', 'http://26.0.172.252:44532', 'http://26.0
+.173.7:28863']
+✅ test generation
+✅ test generation
+✅ test generation
+✅ test generation
+✅ test generation
+running sudo docker run -d -p 37809:37809 --network host -v $(pwd)/slurm/tgi_1706882419_load_balancer.conf:/etc/nginx/nginx.conf nginx
+running sudo docker logs 520880ab48aa6563ebf2a85f5af02d3bfce7780fb498ec06e4bde92af924ab56
+/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
+/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
+/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
+10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
+/docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
+/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
+/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
+/docker-entrypoint.sh: Configuration complete; ready for start up
+🔥 endpoint ready http://localhost:37809
+llm_swarm.suggested_max_parallel_requests was 2500
+  3%|███▏                                                                                                              | 1393/50000 [02:06<38:47, 20.88it/s]
+Request failed, retrying in 5 seconds... (Attempt 1/3)
+ 47%|█████████████████████████████████████████████████████▏                                                           | 23550/50000 [22:09<23:24, 18.84it/s]
+Request failed, retrying in 5 seconds... (Attempt 1/3)
+ 96%|████████████████████████████████████████████████████████████████████████████████████████████████████████████▍    | 47997/50000 [44:20<02:19, 14.35it/s]
+Request failed, retrying in 5 seconds... (Attempt 2/3)
+96%|████████████████████████████████████████████████████████████████████████████████████████████████████████████▋    | 48104/50000 [44:25<01:34, 20.13it/s]
+Max retries reached. Failed to process the request with error Input validation error: `inputs` must have less than 2048 tokens. Given: 2085.
+Max retries reached. Failed to process the request with error Input validation error: `inputs` must have less than 2048 tokens. Given: 2134.
+100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50000/50000 [45:50<00:00, 18.18it/s]
+Overall Tokens per Second: 15596.257617119521
+Dataset({
+    features: ['prompt', 'unit', 'book title', 'audience', 'completion', 'token_length'],
+    num_rows: 50000
+})
+Creating parquet from Arrow format: 100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [00:00<00:00, 56.37ba/s]
+Uploading the dataset shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.81s/it]
+running scancel 1625161
+running scancel 1625162
+running scancel 1625163
+running scancel 1625164
+running scancel 1625165
 ```

--- a/examples/textbooks/readme.md
+++ b/examples/textbooks/readme.md
@@ -1,5 +1,6 @@
-# Installation
+# Guidelines
 
-Install inference-swarm and the requirements in the example.
 
-Install `datatrove` from source
+```
+python ./examples/textbooks/generate_openstax.py --tgi_instances 2 --max_samples 10000
+```

--- a/templates/tgi_h100.template.slurm
+++ b/templates/tgi_h100.template.slurm
@@ -39,13 +39,13 @@ srun --container-image='ghcr.io#huggingface/text-generation-inference' \
     --container-env=HUGGING_FACE_HUB_TOKEN,PORT \
     --container-mounts="$volume:/data" \
     --no-container-mount-home \
-    --qos normal \
+    --qos high \
     /usr/local/bin/text-generation-launcher \
     --model-id $model \
     --revision $revision \
     --max-concurrent-requests 2000 \
     --max-total-tokens 8192 \
-    --max-input-length 7144 \
-    --max-batch-prefill-tokens 8192 \
+    --max-input-length 2048 \
+    --max-batch-prefill-tokens 7168 \
 
 echo "End of job"

--- a/templates/tgi_h100.template.slurm
+++ b/templates/tgi_h100.template.slurm
@@ -45,7 +45,7 @@ srun --container-image='ghcr.io#huggingface/text-generation-inference' \
     --revision $revision \
     --max-concurrent-requests 2000 \
     --max-total-tokens 8192 \
-    --max-input-length 2048 \
+    --max-input-length 7144 \
     --max-batch-prefill-tokens 8192 \
 
 echo "End of job"

--- a/templates/tgi_h100.template.slurm
+++ b/templates/tgi_h100.template.slurm
@@ -39,13 +39,13 @@ srun --container-image='ghcr.io#huggingface/text-generation-inference' \
     --container-env=HUGGING_FACE_HUB_TOKEN,PORT \
     --container-mounts="$volume:/data" \
     --no-container-mount-home \
-    --qos high \
+    --qos normal \
     /usr/local/bin/text-generation-launcher \
     --model-id $model \
     --revision $revision \
     --max-concurrent-requests 2000 \
     --max-total-tokens 8192 \
     --max-input-length 2048 \
-    --max-batch-prefill-tokens 7168 \
+    --max-batch-prefill-tokens 8192 \
 
 echo "End of job"


### PR DESCRIPTION
Increasing  the number of samples & instances seems to overload the endpoints otherwise, this suggestion from @vwxyzjn seems to fix it