### PR TITLE
Per instance max connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,23 @@ When you are done, you can press `Enter` to stop the instances.
 
 
 
+## What if I hit errors mid-generation?
+
+If you hit errors mid-generation, you can inspect the logs in `./slurm/logs` and the slurm files in `./slurm` to debug. Sometimes it is possible you are overloading the servers, so there are two approaches to address it:
+
+1) Set a lower maximum parallel requests. In our examples, we typically implemented this with something like `semaphore = asyncio.Semaphore(max_requests)`. This is a simple way to limit the number of parallel requests. We typically provide a suggested value
+
+```python
+# under the hood
+# llm_swarm.suggested_max_parallel_requests = 
+
+with LLMSwarm(isc) as llm_swarm:
+    semaphore = asyncio.Semaphore(llm_swarm.suggested_max_parallel_requests)
+```
+
+You can set `--per_instance_max_parallel_requests` to a lower number to limit the number of parallel requests initia
+
+
 # Installing TGI from scratch (Dev notes)
 
 ```

--- a/llm_swarm/__init__.py
+++ b/llm_swarm/__init__.py
@@ -32,6 +32,8 @@ class LLMSwarmConfig:
     """number of gpus per instance"""
     load_balancer_template_path: str = "templates/nginx.template.conf"
     """path to load balancer template"""
+    per_instance_max_connection: int = 500
+    """maximum number of parallel requests per instance"""
     debug_endpoint: Optional[str] = None
     """endpoint to use for debugging (e.g. http://localhost:13120)"""
 
@@ -189,9 +191,11 @@ class LLMSwarm:
                 self.endpoint = f"{self.config.debug_endpoint}/generate"
             if self.config.debug_endpoint.startswith("https://api-inference.huggingface.co/"):
                 self.suggested_max_parallel_requests = 40
+            else:
+                self.suggested_max_parallel_requests = self.config.per_instance_max_connection
             return
 
-        self.suggested_max_parallel_requests = 500 * self.config.instances  # some experience values
+        self.suggested_max_parallel_requests = self.config.per_instance_max_connection * self.config.instances
         with open(self.config.slurm_template_path) as f:
             slurm_template = f.read()
 

--- a/llm_swarm/__init__.py
+++ b/llm_swarm/__init__.py
@@ -32,7 +32,7 @@ class LLMSwarmConfig:
     """number of gpus per instance"""
     load_balancer_template_path: str = "templates/nginx.template.conf"
     """path to load balancer template"""
-    per_instance_max_connection: int = 500
+    per_instance_max_parallel_requests: int = 500
     """maximum number of parallel requests per instance"""
     debug_endpoint: Optional[str] = None
     """endpoint to use for debugging (e.g. http://localhost:13120)"""
@@ -192,10 +192,10 @@ class LLMSwarm:
             if self.config.debug_endpoint.startswith("https://api-inference.huggingface.co/"):
                 self.suggested_max_parallel_requests = 40
             else:
-                self.suggested_max_parallel_requests = self.config.per_instance_max_connection
+                self.suggested_max_parallel_requests = self.config.per_instance_max_parallel_requests
             return
 
-        self.suggested_max_parallel_requests = self.config.per_instance_max_connection * self.config.instances
+        self.suggested_max_parallel_requests = self.config.per_instance_max_parallel_requests * self.config.instances
         with open(self.config.slurm_template_path) as f:
             slurm_template = f.read()
 


### PR DESCRIPTION
This PR makes the experience with using `asyncio.Semaphore` even better with a `--per_instance_max_parallel_requests` flag.