### PR TITLE
Fix 2 typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Note that we our slurm templates use Pyxis and Enroot for deploying Docker conta
 
 ## Benchmark
 
-We also include a nice utiliy script to benchmark throughput. You can run it like below:
+We also include a nice utility script to benchmark throughput. You can run it like below:
 
 ```bash
 # tgi
@@ -342,7 +342,7 @@ with LLMSwarm(isc) as llm_swarm:
     semaphore = asyncio.Semaphore(llm_swarm.suggested_max_parallel_requests)
 ```
 
-You can set `--per_instance_max_parallel_requests` to a lower number to limit the number of parallel requests initia
+You can set `--per_instance_max_parallel_requests` to a lower number to limit the number of parallel requests initiated per instance
 
 
 # Installing TGI from scratch (Dev notes)


### PR DESCRIPTION
## Summary
Fixed 2 typos in README.md

## Changes
- Line 155: `utiliy` -> `utility`
- Line 345: `initia` -> `initiated`
  - Seems the sentence got truncated, filled it as `parallel requests initiated per instance`

## Context
**Line 155:** We also include a nice utiliy script to benchmark throughput. You can run it lik...
**Line 345:** You can set  to a lower number to limit the number of parallel requests initia...

